### PR TITLE
Re-enable support for external secondary CSV instances

### DIFF
--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -50,7 +50,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -104,7 +103,6 @@ import org.javarosa.xpath.expr.XPathNumericLiteral;
 import org.javarosa.xpath.expr.XPathPathExpr;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.kxml2.io.KXmlParser;
-import org.kxml2.io.KXmlSerializer;
 import org.kxml2.kdom.Document;
 import org.kxml2.kdom.Element;
 import org.kxml2.kdom.Node;
@@ -1849,24 +1847,6 @@ public class XFormParser implements IXFormParserFunctions {
         "requiredMsg",
         "saveIncomplete"
     ));
-
-    private String toXMLTag(Element element) {
-        String converted = "";
-        KXmlSerializer kXmlSerializer = new KXmlSerializer();
-        StringWriter stringWriter = new StringWriter();
-        kXmlSerializer.setOutput(stringWriter);
-        try {
-            element.write(kXmlSerializer);
-            kXmlSerializer.flush();
-            kXmlSerializer.endDocument();
-            stringWriter.close();
-            converted = stringWriter.toString();
-        } catch (IOException e) {
-            System.out.println(e.toString());
-        }
-
-        return converted;
-    }
 
     private void parseBind(Element element) {
         final DataBinding binding = processStandardBindAttributes(usedAtts, passedThroughAtts, element);

--- a/src/main/java/org/javarosa/xform/parse/XFormParser.java
+++ b/src/main/java/org/javarosa/xform/parse/XFormParser.java
@@ -175,7 +175,7 @@ public class XFormParser implements IXFormParserFunctions {
 
     private final List<WarningCallback> warningCallbacks = new ArrayList<>();
     private final List<ErrorCallback> errorCallbacks = new ArrayList<>();
-    private final SecondaryInstanceAnalyzer secondaryInstanceAnalyzer = new SecondaryInstanceAnalyzer();
+    private SecondaryInstanceAnalyzer secondaryInstanceAnalyzer = new SecondaryInstanceAnalyzer();
 
     //incremented to provide unique question ID for each question
     private int serialQuestionID = 1;
@@ -324,6 +324,7 @@ public class XFormParser implements IXFormParserFunctions {
         mainInstanceNode = null;
         instanceNodes = new ArrayList<>();
         instanceNodeIdStrs = new ArrayList<>();
+        secondaryInstanceAnalyzer = new SecondaryInstanceAnalyzer();
 
         itextKnownForms = new ArrayList<>(4);
         itextKnownForms.add("long");

--- a/src/main/java/org/javarosa/xform/util/SecondaryInstanceAnalyzer.java
+++ b/src/main/java/org/javarosa/xform/util/SecondaryInstanceAnalyzer.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 
 import static org.javarosa.xform.util.XFormSerializer.elementToString;
 
+
 public class SecondaryInstanceAnalyzer {
     // a list of SIs that need to be built in memory
     private final List<String> inMemorySecondaryInstances;

--- a/src/main/java/org/javarosa/xform/util/SecondaryInstanceAnalyzer.java
+++ b/src/main/java/org/javarosa/xform/util/SecondaryInstanceAnalyzer.java
@@ -1,14 +1,13 @@
 package org.javarosa.xform.util;
 
-import org.kxml2.io.KXmlSerializer;
 import org.kxml2.kdom.Element;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static org.javarosa.xform.util.XFormSerializer.elementToString;
 
 public class SecondaryInstanceAnalyzer {
     // a list of SIs that need to be built in memory
@@ -20,26 +19,11 @@ public class SecondaryInstanceAnalyzer {
         inMemorySecondaryInstances = new ArrayList<>();
     }
 
-    private String toXMLTag(Element element) {
-        String converted = "";
-        KXmlSerializer kXmlSerializer = new KXmlSerializer();
-        StringWriter stringWriter = new StringWriter();
-        kXmlSerializer.setOutput(stringWriter);
-        try {
-            element.write(kXmlSerializer);
-            kXmlSerializer.flush();
-            kXmlSerializer.endDocument();
-            stringWriter.close();
-            converted = stringWriter.toString();
-        } catch (IOException e) {
-            System.out.println(e.toString());
-        }
-
-        return converted;
-    }
-
     public void analyzeElement(Element element) {
-        String elementTagString = toXMLTag(element);
+        String elementTagString = elementToString(element);
+        if (elementTagString == null)
+            return;
+
         Matcher matcher = INSTANCE_FUNCTION_PATTERN.matcher(elementTagString);
         String functionFirstParam = matcher.find() ? matcher.group(1) : null;
         if (functionFirstParam != null && !inMemorySecondaryInstances.contains(functionFirstParam))

--- a/src/main/java/org/javarosa/xform/util/SecondaryInstanceAnalyzer.java
+++ b/src/main/java/org/javarosa/xform/util/SecondaryInstanceAnalyzer.java
@@ -1,0 +1,56 @@
+package org.javarosa.xform.util;
+
+import org.kxml2.io.KXmlSerializer;
+import org.kxml2.kdom.Element;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SecondaryInstanceAnalyzer {
+    // a list of SIs that need to be built in memory
+    private final List<String> inMemorySecondaryInstances;
+
+    private final Pattern INSTANCE_FUNCTION_PATTERN = Pattern.compile("instance\\s*\\(\\s*'([^\\s]{1,64})'\\s*");
+
+    public SecondaryInstanceAnalyzer() {
+        inMemorySecondaryInstances = new ArrayList<>();
+    }
+
+    private String toXMLTag(Element element) {
+        String converted = "";
+        KXmlSerializer kXmlSerializer = new KXmlSerializer();
+        StringWriter stringWriter = new StringWriter();
+        kXmlSerializer.setOutput(stringWriter);
+        try {
+            element.write(kXmlSerializer);
+            kXmlSerializer.flush();
+            kXmlSerializer.endDocument();
+            stringWriter.close();
+            converted = stringWriter.toString();
+        } catch (IOException e) {
+            System.out.println(e.toString());
+        }
+
+        return converted;
+    }
+
+    public void analyzeElement(Element element) {
+        String elementTagString = toXMLTag(element);
+        Matcher matcher = INSTANCE_FUNCTION_PATTERN.matcher(elementTagString);
+        String functionFirstParam = matcher.find() ? matcher.group(1) : null;
+        if (functionFirstParam != null && !inMemorySecondaryInstances.contains(functionFirstParam))
+            inMemorySecondaryInstances.add(functionFirstParam);
+    }
+
+    public List<String> getInMemorySecondaryInstances() {
+        return inMemorySecondaryInstances;
+    }
+
+    public boolean shouldSecondaryInstanceBeParsed(String instanceId) {
+        return inMemorySecondaryInstances.contains(instanceId);
+    }
+}

--- a/src/test/java/org/javarosa/xform/parse/XFormParserTest.java
+++ b/src/test/java/org/javarosa/xform/parse/XFormParserTest.java
@@ -17,6 +17,7 @@ import static org.javarosa.xpath.XPathParseTool.parseXPath;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.DataInputStream;
@@ -30,6 +31,7 @@ import java.nio.file.Path;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Enumeration;
 import java.util.List;
 import org.javarosa.core.model.CoreModelModule;
 import org.javarosa.core.model.FormDef;
@@ -128,6 +130,19 @@ public class XFormParserTest {
         setUpSimpleReferenceManager("file-csv", form.getParent());
         FormDef formDef = parse(form);
         assertEquals("Sample Form - Preloading", formDef.getTitle());
+    }
+
+    @Test
+    public void parsesExternalSecondaryInstanceAsFormInstance() throws IOException {
+        Path form = r("Sample-Preloading.xml");
+        setUpSimpleReferenceManager("file-csv", form.getParent());
+        FormDef formDef = parse(form);
+        Enumeration<DataInstance> elements = formDef.getNonMainInstances();
+
+        while (elements.hasMoreElements()) {
+            DataInstance instance = elements.nextElement();
+            assertTrue(instance instanceof FormInstance);
+        }
     }
 
     @Test

--- a/src/test/java/org/javarosa/xform/util/test/SecondaryInstanceAnalyzerTest.java
+++ b/src/test/java/org/javarosa/xform/util/test/SecondaryInstanceAnalyzerTest.java
@@ -19,22 +19,25 @@ import static org.junit.Assert.assertEquals;
 public class SecondaryInstanceAnalyzerTest {
     private static final Logger logger = LoggerFactory.getLogger(SecondaryInstanceAnalyzer.class);
 
+    private void parseElement(Element element, SecondaryInstanceAnalyzer secondaryInstanceAnalyzer) {
+        for (int i = 0; i < element.getChildCount(); i++) {
+            if (element.getType(i) == Element.ELEMENT) {
+                secondaryInstanceAnalyzer.analyzeElement(element);
+                parseElement(element.getElement(i), secondaryInstanceAnalyzer);
+            }
+        }
+    }
+
     @Test
     public void getIDFromAttributes() throws IOException {
         String filePath = r("secondary-instance-test.xml").toString();
         Document doc = XFormParser.getXMLDocument(new FileReader(filePath));
         Element root = doc.getRootElement();
         SecondaryInstanceAnalyzer secondaryInstanceAnalyzer = new SecondaryInstanceAnalyzer();
-        int count = root.getChildCount();
-
-
-        for (int i = 0; i < count; i++) {
-            Element element = root.getElement(i);
-            secondaryInstanceAnalyzer.analyzeElement(element);
-        }
+        parseElement(root, secondaryInstanceAnalyzer);
 
         assertEquals(secondaryInstanceAnalyzer.getInMemorySecondaryInstances().toArray().length, 2);
-        assertFalse(secondaryInstanceAnalyzer.shouldSecondaryInstanceBeParsed("esi-id-3"));
-        assertTrue(secondaryInstanceAnalyzer.shouldSecondaryInstanceBeParsed("esi-id-1"));
+        assertFalse(secondaryInstanceAnalyzer.shouldSecondaryInstanceBeParsed("country"));
+        assertTrue(secondaryInstanceAnalyzer.shouldSecondaryInstanceBeParsed("lgas"));
     }
 }

--- a/src/test/java/org/javarosa/xform/util/test/SecondaryInstanceAnalyzerTest.java
+++ b/src/test/java/org/javarosa/xform/util/test/SecondaryInstanceAnalyzerTest.java
@@ -1,0 +1,40 @@
+package org.javarosa.xform.util.test;
+
+import org.javarosa.xform.parse.XFormParser;
+import org.javarosa.xform.util.SecondaryInstanceAnalyzer;
+import org.junit.Test;
+import org.kxml2.kdom.Document;
+import org.kxml2.kdom.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileReader;
+import java.io.IOException;
+
+import static org.javarosa.test.utils.ResourcePathHelper.r;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+public class SecondaryInstanceAnalyzerTest {
+    private static final Logger logger = LoggerFactory.getLogger(SecondaryInstanceAnalyzer.class);
+
+    @Test
+    public void getIDFromAttributes() throws IOException {
+        String filePath = r("secondary-instance-test.xml").toString();
+        Document doc = XFormParser.getXMLDocument(new FileReader(filePath));
+        Element root = doc.getRootElement();
+        SecondaryInstanceAnalyzer secondaryInstanceAnalyzer = new SecondaryInstanceAnalyzer();
+        int count = root.getChildCount();
+
+
+        for (int i = 0; i < count; i++) {
+            Element element = root.getElement(i);
+            secondaryInstanceAnalyzer.analyzeElement(element);
+        }
+
+        assertEquals(secondaryInstanceAnalyzer.getInMemorySecondaryInstances().toArray().length, 2);
+        assertFalse(secondaryInstanceAnalyzer.shouldSecondaryInstanceBeParsed("esi-id-3"));
+        assertTrue(secondaryInstanceAnalyzer.shouldSecondaryInstanceBeParsed("esi-id-1"));
+    }
+}

--- a/src/test/resources/secondary-instance-test.xml
+++ b/src/test/resources/secondary-instance-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<root>
+    <instance id="esi-id-1" src="jr://file-csv/no-file-1.csv" />
+    <instance id="esi-id-2" src="jr://file-csv/no-file-2.csv" />
+    <instance id="esi-id-3" src="jr://file-csv/no-file-3.csv" />
+
+    <element attr="instance('esi-id-1')" />
+    <element attr="instance('esi-id-2')" />
+    <element attr="instance('esi-id-2')" />
+
+    <element attr="pulldata('esi-id-1')" />
+    <element attr="pulldata('esi-id-3')" />
+</root>

--- a/src/test/resources/secondary-instance-test.xml
+++ b/src/test/resources/secondary-instance-test.xml
@@ -1,13 +1,208 @@
 <?xml version="1.0"?>
-<root>
-    <instance id="esi-id-1" src="jr://file-csv/no-file-1.csv" />
-    <instance id="esi-id-2" src="jr://file-csv/no-file-2.csv" />
-    <instance id="esi-id-3" src="jr://file-csv/no-file-3.csv" />
-
-    <element attr="instance('esi-id-1')" />
-    <element attr="instance('esi-id-2')" />
-    <element attr="instance('esi-id-2')" />
-
-    <element attr="pulldata('esi-id-1')" />
-    <element attr="pulldata('esi-id-3')" />
-</root>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>Nigeria Wards External</h:title>
+        <model>
+            <instance>
+                <nigeria_wards_external id="nigeria_wards_external">
+                    <state/>
+                    <lga/>
+                    <ward/>
+                    <comments/>
+                    <target_pop/>
+                    <pop_filter/>
+                    <pop_filter_label/>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </nigeria_wards_external>
+            </instance>
+            <instance id="lgas" src="jr://file/lgas.xml" />
+            <instance id="wards" src="jr://file/wards.xml" />
+            <instance id="states">
+                <root>
+                    <item>
+                        <itextId>static_instance-states-0</itextId>
+                        <name>7b0ded95031647702b8bed17dce7698a</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-1</itextId>
+                        <name>bab9572e912b499ca4ac845a1289fc71</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-2</itextId>
+                        <name>d40f981befcd46cf54b075006baf1d95</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-3</itextId>
+                        <name>42319e78985a48cacdf8219a2b2225c9</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-4</itextId>
+                        <name>53fb844b56da888376ba98952e44165f</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-5</itextId>
+                        <name>be5150997fa0e113ecf457f099fb35a7</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-6</itextId>
+                        <name>a6d13cd69feab44de1a69a0221b0c575</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-7</itextId>
+                        <name>84c805ca4fc0d0d9e47045df156b8d08</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-8</itextId>
+                        <name>bb56288c6ccf9b5ca6a582a317a46b16</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-9</itextId>
+                        <name>2a6e2bcca861fc1c32feb45798e5fc7b</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-10</itextId>
+                        <name>fe2f093e55c6e01c88656217dc7eb0d3</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-11</itextId>
+                        <name>11a0f80deaf7fb46838716ef2af6b99e</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-12</itextId>
+                        <name>9b970db22b77c3b62b8e842cb4fcf71f</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-13</itextId>
+                        <name>39f56e1d9edea610c57114bf56e3667c</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-14</itextId>
+                        <name>09e69c1eed9e83a7221b2c5ad6622c62</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-15</itextId>
+                        <name>ad4e766c716d358344965c1c38d838ce</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-16</itextId>
+                        <name>1b14b6066c15ac8011ff8edaf7d50a74</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-17</itextId>
+                        <name>fa0c5ed6ceccefb7ebb4bab7c584939e</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-18</itextId>
+                        <name>26a9c2b0d3242843c6c4782fb4c7d6c7</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-19</itextId>
+                        <name>cf3ccea2e7e522186f1225ec58c9f9c1</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-20</itextId>
+                        <name>ee7ef90cc3e7671cf683f3b6cd6a22fa</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-21</itextId>
+                        <name>ea6e721298b727bc9406b1b2942da6e9</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-22</itextId>
+                        <name>bdec639af472b09fba54502a9e87fb43</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-23</itextId>
+                        <name>18d670862b61551bc5aff5111479455e</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-24</itextId>
+                        <name>e6a9d5d13dd1be2f445439229baa3669</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-25</itextId>
+                        <name>e321471812e5c4b54c9c58319aec9f2b</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-26</itextId>
+                        <name>2d7ea60e3afc65423c79ddea106e0075</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-27</itextId>
+                        <name>9501b8da8871290426c3be65693ebe2a</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-28</itextId>
+                        <name>7d97dcf0a101baea5a5cabab7def80c6</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-29</itextId>
+                        <name>1dbd3ad151ca7750720ee90f62295230</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-30</itextId>
+                        <name>e3fa17628607c70e0e1ee058f2355812</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-31</itextId>
+                        <name>7d5d87993bd73d6daa86ce68e5bf6937</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-32</itextId>
+                        <name>32f6bff0fd33b11a58ad90886c4091be</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-33</itextId>
+                        <name>000d892c27a5b2d43e1ddd1ad411e106</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-34</itextId>
+                        <name>c84f2b52af9b820f4073958e8360ea36</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-35</itextId>
+                        <name>541c29b2f7a15a2f89dba42aac3d9ed6</name>
+                    </item>
+                    <item>
+                        <itextId>static_instance-states-36</itextId>
+                        <name>81f3e4e12571cec3fef659a726a6183f</name>
+                    </item>
+                </root>
+            </instance>
+            <bind nodeset="/nigeria_wards_external/state" type="select1"/>
+            <bind nodeset="/nigeria_wards_external/lga" required="true()" type="select1"/>
+            <bind nodeset="/nigeria_wards_external/ward" required="true()" type="select1"/>
+            <bind nodeset="/nigeria_wards_external/comments" type="string"/>
+            <bind nodeset="/nigeria_wards_external/target_pop" type="string"/>
+            <bind calculate="instance('wards')/root/item[fake_population =  /nigeria_wards_external/target_pop ]/label" nodeset="/nigeria_wards_external/pop_filter" type="string"/>
+            <bind nodeset="/nigeria_wards_external/pop_filter_label" readonly="true()" type="string"/>
+            <bind calculate="concat('uuid:', uuid())" nodeset="/nigeria_wards_external/meta/instanceID" readonly="true()" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <select1 ref="/nigeria_wards_external/lga">
+            <label>LGA</label>
+            <itemset nodeset="instance('lgas')/root/item[state= /nigeria_wards_external/state ]">
+                <value ref="name"/>
+                <label ref="label"/>
+            </itemset>
+        </select1>
+        <select1 ref="/nigeria_wards_external/ward">
+            <label>Ward</label>
+            <itemset nodeset="instance('wards')/root/item[lga= /nigeria_wards_external/lga ]">
+                <value ref="name"/>
+                <label ref="label"/>
+            </itemset>
+        </select1>
+        <input ref="/nigeria_wards_external/comments">
+            <label>Comments</label>
+        </input>
+        <input ref="/nigeria_wards_external/target_pop">
+            <label>What population do you want to search for?</label>
+        </input>
+        <input ref="/nigeria_wards_external/pop_filter_label">
+            <label> Ward with population of <output value=" /nigeria_wards_external/target_pop "/>: <output value=" /nigeria_wards_external/pop_filter "/> </label></input>
+    </h:body>
+</h:html>


### PR DESCRIPTION
Closes #417

#### What has been done to verify that this works as intended?
Test was added to determine when an external secondary instance `id` is referenced in a `pulldata` function that the instance is parsed as Internal form instance (`FormInstance` not `ExternalDataInstance`) without loading the external file into memory.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Enabling external secondary CSV instance  without an update to [FormLoaderTask](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java#L144) will result in forms ESI without `pulldata()` reference throwing `FileNotFoundException`

#### Do we need any specific form for testing your changes? If so, please attach one.
No, the code was tested using [Sample-Preloading](https://github.com/opendatakit/javarosa/blob/master/src/test/resources/Sample-Preloading.xml) form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No
